### PR TITLE
Update VideoStream.java

### DIFF
--- a/src/android/com/webmons/disono/rtmpandrtspstreamer/VideoStream.java
+++ b/src/android/com/webmons/disono/rtmpandrtspstreamer/VideoStream.java
@@ -9,7 +9,7 @@ import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.util.Log;
 
-import com.webmons.disono.libVLC.VLCActivity;
+//import com.webmons.disono.libVLC.VLCActivity;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;


### PR DESCRIPTION
Fix https://github.com/disono/cordova-rtmp-rtsp-stream/issues/2

Fix error: package com.webmons.disono.libVLC does not exist

After remove that line it back to work